### PR TITLE
Fixes to make DeployToBluemix button work

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Replace myapp name with the name of your app (ex. talent-manager)
 
 or click the button below
 
-[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/jsloyer/talent-manager.git)
+[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy)
 
 # About
 ## Meet Ivy

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 declared-services:
   talent-manager-db:
     label: cloudantNoSQLDB
-    plan: shared
+    plan: Shared
   personality-insights-talent-manager:
     label: personality_insights
     plan: "IBM Watson Personality Insights Monthly Plan"


### PR DESCRIPTION
Fixed Cloudant plan name in manifest.yml
Removed the explicit repo location in readme.md (optional, but allows forks to remain relative to copies)
